### PR TITLE
Add support for 04f2:b6f9

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -10,3 +10,9 @@ You can directly use my script.
 __u8 data[2] = {0x02, 0x19};
 .selector = 0x0e,
 .size = 2,
+
+# Clevo NS50MU (System76 Darter Pro (darp7), PCSPECIALIST 15,6" LAFITÉ PRO and TUXEDO InfinityBook S 15 Gen6)
+__u8 data[9] = {0x01,0x00,0x00,0x00};
+.unit = 0x0a, //2 first symbols of wIndex
+.selector = 0x09, //2 first symbols of wValue
+.size = 4, //wLength

--- a/enable-ir-emitter.c
+++ b/enable-ir-emitter.c
@@ -19,16 +19,16 @@ int main() {
     }
 
     //Data Fragment
-    __u8 data[9] = {0x01,0x03,0x02,0x00,0x00,0x00,0x00,0x00,0x00};
+    __u8 data[9] = {0x01,0x00,0x00,0x00};
     //You can use my python data-seq-to-hex script for format the data fragment directly in the buffer format.
     //You just have to pass the data fragment in parameter
     //Don't forget to change the buffer size with the value of wLength
 
     struct uvc_xu_control_query query = {
-        .unit = 0x0e, //2 first symbols of wIndex
-        .selector = 0x06, //2 first symbols of wValue
+        .unit = 0x0a, //2 first symbols of wIndex
+        .selector = 0x09, //2 first symbols of wValue
         .query = UVC_SET_CUR,
-        .size = 9, //wLength
+        .size = 4, //wLength
         .data = (__u8*)&data,
     };
 


### PR DESCRIPTION
This is the device used in the Clevo NS50MU also known as System76 Darter Pro (darp7), PCSPECIALIST 15,6" LAFITÉ PRO and TUXEDO InfinityBook S 15 Gen6