### PR TITLE
Fix systemd service file & script linux-enable-ir-emitter (config file)

### DIFF
--- a/linux-enable-ir-emitter
+++ b/linux-enable-ir-emitter
@@ -2,7 +2,7 @@
 
 BASE_PATH=/usr/lib/linux-enable-ir-emitter/
 PYTHON_FIND_CONFIG_PATH="${BASE_PATH}find-config-ir-emitter.py"
-CONFIG_FILE="${BASE_PATH}config.json"
+CONFIG_FILE="${BASE_PATH}config.yaml"
 BIN_ENABLE_IR_PATH="${BASE_PATH}enable-ir-emitter"
 
 

--- a/linux-enable-ir-emitter.service
+++ b/linux-enable-ir-emitter.service
@@ -4,7 +4,7 @@ After=multi-user.target suspend.target hibernate.target hybrid-sleep.target susp
 
 [Service]
 Type=one-shot
-ExecStart=/usr/bin/linux-enable-ir-emitter -f
+ExecStart=/usr/bin/linux-enable-ir-emitter -rf
 
 [Install]
 WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target


### PR DESCRIPTION
This patch is a fix of the systemd service file. The previous one I made was referring to the wrong command and wrong arguments.

It also fixes the issue of pointing to the wrong configuration file (because of the change from JSON to YAML).