### PR TITLE
Use python3 instead of python

### DIFF
--- a/cleaner
+++ b/cleaner
@@ -36,7 +36,7 @@ uninstall() {
 reinstall() {
   uninstall
   cd auto
-  sudo python auto-config.py
+  sudo python3 auto-config.py
 }
 
 case $1 in


### PR DESCRIPTION
The default `Python` may not be `Python3`, which may result in a failure to execute auto-config.py using python,using python3 to instead python is recommended.

As for me, I has install `virtualbox6.1` which require `python2`, I'm amazing to find my default python was changed to `python2`.
### And the auto-config.py fail to execute using python command (because of python2)
    ~> sudo python auto-config.py
    Traceback (most recent call last):
    File "auto-config.py", line 1, in <module>
    from yaml import load, FullLoader
    ImportError: No module named yaml
    ✘ ~> sudo python3 auto-config.py
    Compilation of the C script ...
    Trying all know infrared camera configuration ...
    Configuration #0 ...
    Ioctl error code: -1, errno: 2
    The device does not support the given control or the specified extension unit could not be found.
    Configuration #0 does not work
    Configuration #1 ...
    A configuration has been found, please test if the emitter of your infrared camera works.
    Does it work? Yes/No ? y
    Do you want to automatically activate the emitter at system startup ? Yes/No ? y
    Creating the script with systemd ... (administrator commands will be executed)
    Creation of the service ...

### Then
    ~> sudo apt install python-is-python3
    Reading package lists... Done
    Building dependency tree... Done
    Reading state information... Done
    The following package was automatically installed and is no longer required:
        libsdl-ttf2.0-0
    Use 'sudo apt autoremove' to remove it.
    The following packages will be REMOVED:
        python-is-python2 virtualbox-6.1
    The following NEW packages will be installed:
        python-is-python3
    0 upgraded, 1 newly installed, 2 to remove and 0 not upgraded.
    Need to get 2,844 B of archives.
    After this operation, 216 MB disk space will be freed.
    Do you want to continue? [Y/n] n
    Abort.