### PR TITLE
Offer a choose to user which allow test in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+auto/enable-ir-emitter
+auto/enable-ir-emitter.service

--- a/auto/auto-config.py
+++ b/auto/auto-config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from yaml import load, FullLoader
 from os import system
 
@@ -35,7 +37,17 @@ if __name__ == "__main__":
         check = ""
         if not res:
             while check not in ("yes", "no", "y", "n"):
-                check = input("A configuration has been found, please test if the emitter of your infrared camera works.\nDoes it work? Yes/No ? ").lower()
+                check = input("A configuration has been found, do you want to test now ? Yes/No ? ").lower()
+
+            if check in ("yes", "y"):
+                check = ""
+                system("python3 capture.py 2 5")
+            else:
+                check = ""
+                print("OK, please test if the emitter of your infrared camera works by yourself.")
+
+            while check not in ("yes", "no", "y", "n"):
+                check = input("Does it work ? Yes/No ? ").lower()
 
             if check in ("yes", "y"):
                 check = ""

--- a/auto/capture.py
+++ b/auto/capture.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# arg1: X from videoX
+# arg2: test time (s)
+
+from cv2 import VideoCapture
+from sys import argv
+from os import system
+
+capture = VideoCapture(int(argv[1]))
+capture.read()
+system("sleep " + argv[2])
+capture.release()

--- a/cleaner
+++ b/cleaner
@@ -9,7 +9,6 @@ usage() {
 Usage:
   bash cleaner [option]
   option:
-    help           print usage of this script
     uninstall      uninstall enable-ir-emitter
     reinstall      reinstall enable-ir-emitter"
 }
@@ -35,14 +34,15 @@ uninstall() {
 
 reinstall() {
   uninstall
-  cd auto
-  sudo python3 auto-config.py
+  cd auto || exit 1
+
+  sudo rm -rf enable-ir-emitter
+  sudo rm -rf enable-ir-emitter.service
+
+  python3 auto-config.py
 }
 
 case $1 in
-  help)
-    usage
-  ;;
   "uninstall")
     uninstall
   ;;
@@ -50,7 +50,7 @@ case $1 in
     reinstall
   ;;
   *)
-    echo "use 'bash cleaner help' for help"
+    usage
     exit 1
   ;;
 esac


### PR DESCRIPTION
Well, I think that a simple capture.py could be used for testing ir-emitter flexible. At the same time, people could also test their camera by their own way more like to. At line 44 of the auto-config.py, I set the default camera to video2 and default test time to 5 sec. These values can be changed at any time. The patch has been tested by myself.