### PR TITLE
Mark systemd as an optional dependency

### DIFF
--- a/AUR/PKGBUILD
+++ b/AUR/PKGBUILD
@@ -12,8 +12,11 @@ license=(MIT)
 provides=(linux-enable-ir-emitter)
 conflicts=(chicony-ir-toggle)
 makedepends=(gcc git make)
-depends=(python python-opencv python-yaml systemd)
-optdepends=('python-pyshark: full configuration setup support')
+depends=(python python-opencv python-yaml)
+optdepends=(
+    'python-pyshark: full configuration setup support'
+    'systemd: system and service manager to support linux-enable-ir-emitter running automatically'
+)
 source=("git+https://github.com/EmixamPP/linux-enable-ir-emitter")
 sha256sums=('SKIP')
 

--- a/AUR/PKGBUILD
+++ b/AUR/PKGBUILD
@@ -5,18 +5,21 @@
 pkgname=linux-enable-ir-emitter
 pkgver=20210725.0
 pkgrel=1
-arch=(x86_64)
 pkgdesc='Enables infrared cameras that are not directly enabled out-of-the box.'
 url='https://github.com/EmixamPP/linux-enable-ir-emitter'
 license=(MIT)
+arch=(x86_64)
+
 provides=(linux-enable-ir-emitter)
 conflicts=(chicony-ir-toggle)
-makedepends=(gcc git make)
-depends=(python python-opencv python-yaml)
+
+makedepends=('gcc' 'git' 'make')
+depends=('python' 'python-opencv' 'python-yaml')
 optdepends=(
     'python-pyshark: full configuration setup support'
     'systemd: system and service manager to support linux-enable-ir-emitter running automatically'
 )
+
 source=("git+https://github.com/EmixamPP/linux-enable-ir-emitter")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
The `systemd` should be marked as an `optdepends` since `linux-enable-ir-emitter` can be run manually.

``` patch
diff --git a/AUR/PKGBUILD b/AUR/PKGBUILD
index 8bd2fd5..6bb534a 100644
--- a/AUR/PKGBUILD
+++ b/AUR/PKGBUILD
@@ -5,15 +5,21 @@
 pkgname=linux-enable-ir-emitter
 pkgver=20210725.0
 pkgrel=1
-arch=(x86_64)
 pkgdesc='Enables infrared cameras that are not directly enabled out-of-the box.'
 url='https://github.com/EmixamPP/linux-enable-ir-emitter'
 license=(MIT)
+arch=(x86_64)
+
 provides=(linux-enable-ir-emitter)
 conflicts=(chicony-ir-toggle)
-makedepends=(gcc git make)
-depends=(python python-opencv python-yaml systemd)
-optdepends=('python-pyshark: full configuration setup support')
+
+makedepends=('gcc' 'git' 'make')
+depends=('python' 'python-opencv' 'python-yaml')
+optdepends=(
+    'python-pyshark: full configuration setup support'
+    'systemd: system and service manager to support linux-enable-ir-emitter running automatically'
+)
+
 source=("git+https://github.com/EmixamPP/linux-enable-ir-emitter")
 sha256sums=('SKIP')
 
```