### PR TITLE
Maybe fix boot service path for debian/ubuntu

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -41,6 +41,7 @@ do_uninstall() {
     rm -fv /usr/bin/linux-enable-ir-emitter 
     rm -rfv /usr/lib/linux-enable-ir-emitter/
     rm -fv /usr/lib/systemd/system/linux-enable-ir-emitter.service
+    rm -fv /lib/systemd/system/linux-enable-ir-emitter.service
     rm -fv /etc/linux-enable-ir-emitter.yaml
 }
 


### PR DESCRIPTION
debian and debian-like have the ID with `debian` in /etc/os-release, this maybe helpful for fix boot service path.
``` patch
diff --git a/installer.sh b/installer.sh
index 84ae248..4052cb1 100644
--- a/installer.sh
+++ b/installer.sh
@@ -26,7 +26,9 @@ do_install() {
     install -Dm 755 sources/driver/uvc/*query.o  -t /usr/lib/linux-enable-ir-emitter/driver/uvc/ -v
     
     # boot service
-    install -Dm 644 sources/linux-enable-ir-emitter.service -t /usr/lib/systemd/system/ -v
+    [[ $(cat /etc/os-release | grep 'debian') ]] &&
+        install -Dm 644 sources/linux-enable-ir-emitter.service -t /lib/systemd/system/ -v ||
+        install -Dm 644 sources/linux-enable-ir-emitter.service -t /usr/lib/systemd/system/ -v
 
     # executable
     chmod +x /usr/lib/linux-enable-ir-emitter/linux-enable-ir-emitter.py
@@ -39,6 +41,7 @@ do_uninstall() {
     rm -fv /usr/bin/linux-enable-ir-emitter 
     rm -rfv /usr/lib/linux-enable-ir-emitter/
     rm -fv /usr/lib/systemd/system/linux-enable-ir-emitter.service
+    rm -fv /lib/systemd/system/linux-enable-ir-emitter.service
     rm -fv /etc/linux-enable-ir-emitter.yaml
 }
 
```