### PR TITLE
Release AUR package fix for 3.2.0

### DIFF
--- a/AUR/release/PKGBUILD
+++ b/AUR/release/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=linux-enable-ir-emitter
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Enables infrared cameras that are not directly enabled out-of-the box."
 url='https://github.com/EmixamPP/linux-enable-ir-emitter'
@@ -24,7 +24,7 @@ source=("https://github.com/EmixamPP/linux-enable-ir-emitter/archive/refs/tags/$
 sha256sums=('SKIP')
 
 build() {
-    make -C "${srcdir}/${pkgname}-${pkgver}/sources/uvc"
+    make -C "${srcdir}/${pkgname}-${pkgver}/sources/driver/uvc"
 }
 
 package() {


### PR DESCRIPTION
Same with the AUR upload but leave `SKIP` in checksums.

BTW, the git version is already work fine.