### PR TITLE
Add `pre_remove`

### DIFF
--- a/AUR/git/linux-enable-ir-emitter.install
+++ b/AUR/git/linux-enable-ir-emitter.install
@@ -1,3 +1,8 @@
+pre_remove() {
+  # disable service and remove targets
+  linux-enable-ir-emitter boot disable
+}
+
 post_remove() {
   # delete files added after user configure
   rm -f /etc/linux-enable-ir-emitter.yaml

--- a/AUR/release/linux-enable-ir-emitter.install
+++ b/AUR/release/linux-enable-ir-emitter.install
@@ -1,3 +1,8 @@
+pre_remove() {
+  # disable service and remove targets
+  linux-enable-ir-emitter boot disable
+}
+
 post_remove() {
   # delete files added after user configure
   rm -f /etc/linux-enable-ir-emitter.yaml

--- a/sources/command/configure.py
+++ b/sources/command/configure.py
@@ -17,7 +17,7 @@ def execute(device: str, neg_answer_limit: int) -> None:
 
     driver_generator = DriverGenerator(device, neg_answer_limit)
     
-    logging.info("Warning to do not kill the processus !")
+    logging.info("Warning to do not kill the processes !")
     try:
         driver_generator.generate()
         if driver_generator.driver:


### PR DESCRIPTION
Changes:
- Add `pre_remove` for remove dead symbolic links in `/etc/systemd/system`
- Correct a word maybe mistake in `sources/command/configure.py`

``` patch
diff --git a/AUR/git/linux-enable-ir-emitter.install b/AUR/git/linux-enable-ir-emitter.install
index 0f30514..c7cafdd 100644
--- a/AUR/git/linux-enable-ir-emitter.install
+++ b/AUR/git/linux-enable-ir-emitter.install
@@ -1,3 +1,8 @@
+pre_remove() {
+  # disable service and remove targets
+  linux-enable-ir-emitter boot disable
+}
+
 post_remove() {
   # delete files added after user configure
   rm -f /etc/linux-enable-ir-emitter.yaml
diff --git a/AUR/release/linux-enable-ir-emitter.install b/AUR/release/linux-enable-ir-emitter.install
index 0f30514..c7cafdd 100644
--- a/AUR/release/linux-enable-ir-emitter.install
+++ b/AUR/release/linux-enable-ir-emitter.install
@@ -1,3 +1,8 @@
+pre_remove() {
+  # disable service and remove targets
+  linux-enable-ir-emitter boot disable
+}
+
 post_remove() {
   # delete files added after user configure
   rm -f /etc/linux-enable-ir-emitter.yaml
diff --git a/sources/command/configure.py b/sources/command/configure.py
index 82d10f7..dabf263 100644
--- a/sources/command/configure.py
+++ b/sources/command/configure.py
@@ -17,7 +17,7 @@ def execute(device: str, neg_answer_limit: int) -> None:
 
     driver_generator = DriverGenerator(device, neg_answer_limit)
     
-    logging.info("Warning to do not kill the processus !")
+    logging.info("Warning to do not kill the processes !")
     try:
         driver_generator.generate()
         if driver_generator.driver:
```