### PR TITLE
A small fix for git version `PKGBUILD`

### DIFF
--- a/AUR/git/PKGBUILD
+++ b/AUR/git/PKGBUILD
@@ -26,11 +26,11 @@ pkgver() {
 }
 
 build() {
-    make -C "${srcdir}/${pkgname}-${pkgver}/sources/driver/uvc"
+    make -C "${srcdir}/${pkgname/-git}/sources/driver/uvc"
 }
 
 package() {
-    cd "${srcdir}/${pkgname}-${pkgver}"
+    cd "${srcdir}/${pkgname/-git}"
 
     install -Dm 644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}"
 


### PR DESCRIPTION
<details>
<summary> Changes </summary>

``` patch
diff --git a/AUR/git/PKGBUILD b/AUR/git/PKGBUILD
index a62bef3..62c619d 100644
--- a/AUR/git/PKGBUILD
+++ b/AUR/git/PKGBUILD
@@ -26,11 +26,11 @@ pkgver() {
 }
 
 build() {
-    make -C "${srcdir}/${pkgname}-${pkgver}/sources/driver/uvc"
+    make -C "${srcdir}/${pkgname/-git}/sources/driver/uvc"
 }
 
 package() {
-    cd "${srcdir}/${pkgname}-${pkgver}"
+    cd "${srcdir}/${pkgname/-git}"
 
     install -Dm 644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}"
 
```
</details>