### PR TITLE
Fix bogus date in changelog

### DIFF
--- a/COPR/linux-enable-ir-emitter.spec
+++ b/COPR/linux-enable-ir-emitter.spec
@@ -98,7 +98,7 @@ fi
 - Asynchronous camera triggering
 - Fix camera triggering issue
 - Fix device symlink boot service side effect
-* Sat Jun 19 2022 Maxime Dirksen <copr@emixam.be> - 4.0.0-1
+* Sun Jun 19 2022 Maxime Dirksen <copr@emixam.be> - 4.0.0-1
 - Rework, optimization and improvement of driver generation 
 - Remove manual configuration commands
 - Remove option for integration into Howdy


### PR DESCRIPTION
Fixes `SPEC` file so that it satisfies `rpmlint`.

 `warning: bogus date in %changelog: Sat Jun 19 2022 Maxime Dirksen <copr@emixam.be> - 4.0.0-1`