### PR TITLE
Fix invalid PKGBUILDs

### DIFF
--- a/AUR/git/PKGBUILD
+++ b/AUR/git/PKGBUILD
@@ -9,7 +9,7 @@ pkgrel=1
 pkgdesc="Enables infrared cameras that are not directly enabled out-of-the box"
 url="https://github.com/EmixamPP/linux-enable-ir-emitter"
 license=('MIT')
-arch=('x86_64', 'aarch64')
+arch=('x86_64' 'aarch64')
 
 provides=(linux-enable-ir-emitter)
 conflicts=(linux-enable-ir-emitter chicony-ir-toggle)

--- a/AUR/release/PKGBUILD
+++ b/AUR/release/PKGBUILD
@@ -11,7 +11,7 @@ epoch=1
 pkgdesc="Enables infrared cameras that are not directly enabled out-of-the box."
 url='https://github.com/EmixamPP/linux-enable-ir-emitter'
 license=('MIT')
-arch=('x86_64', 'aarch64')
+arch=('x86_64' 'aarch64')
 
 provides=(linux-enable-ir-emitter)
 conflicts=(linux-enable-ir-emitter-git chicony-ir-toggle)


### PR DESCRIPTION
The PKGBUILD spec doesn't allow commas as separators