### PR TITLE
Python >= 3.10

### DIFF
--- a/sources/boot_service/base_boot_service.py
+++ b/sources/boot_service/base_boot_service.py
@@ -1,8 +1,7 @@
-from abc import ABCMeta, abstractmethod
-from typing import List
-import subprocess
 import logging
 import os
+import subprocess
+from abc import ABCMeta, abstractmethod
 
 from globals import UDEV_RULE_PATH, get_index, get_kernels
 
@@ -10,49 +9,60 @@ from globals import UDEV_RULE_PATH, get_index, get_kernels
 class BaseBootService(metaclass=ABCMeta):
     """Manage the boot service of linux-enable-ir-emitter"""
 
-    def __init__(self, devices: List[str]) -> None:
-        """Create a boot service for run the drivers
+    def __init__(self, devices: list[str]) -> None:
+        """Create a boot service for run the drivers.
 
         Args:
-            devices : devices for which a driver will be run
+            devices (list[str]): devices for which a driver will be run.
         """
-        self.devices = devices
+        self.devices: list[str] = devices
 
     @abstractmethod
     def _enable(self) -> int:
-        """Enable the service
+        """Enable the service.
 
         Returns:
-            0: the service have been enabled successfully
-            other value: Error with the boot service.
+            int: 0 if the service have been enabled successfully.
+            Otherwise, error with the boot service.
         """
 
     @abstractmethod
     def _disable(self) -> int:
-        """Disable the service
+        """Disable the service.
 
         Returns:
-            0: the service have been disabled successfully
-            other value: The boot service does not exists.
+            int: 0 if the service have been disabled successfully.
+            Otherwise, error with the boot service.
         """
 
     @abstractmethod
     def status(self) -> int:
         """Print the service status
+
         Returns:
-            0: the service works fine
-            other value: error with the boot service
+            int: 0 if the service works fine.
+            Otherwise, error with the boot service.
         """
 
     def enable(self) -> int:
+        """Enable the service.
+
+        Returns:
+            int: 0 if the service have been enabled successfully.
+            Otherwise, error with the boot service.
+        """
         self._create_udev()
 
-        exit_code = subprocess.run(
-            ["udevadm", "control", "--reload-rules"], capture_output=True
-        ).returncode
-        exit_code += subprocess.run(
-            ["udevadm", "trigger"], capture_output=True
-        ).returncode
+        exit_code = subprocess.call(
+            ["udevadm", "control", "--reload-rules"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        exit_code += subprocess.call(
+            ["udevadm", "trigger"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         if exit_code:
             logging.error("Error with the udev boot service.")
@@ -61,6 +71,12 @@ class BaseBootService(metaclass=ABCMeta):
         return exit_code
 
     def disable(self) -> int:
+        """Disable the service.
+
+        Returns:
+            int: 0 if the service have been disabled successfully.
+            Otherwise, error with the boot service.
+        """
         try:
             os.remove(UDEV_RULE_PATH)
             exit_code = 0

--- a/sources/boot_service/openrc/openrc.py
+++ b/sources/boot_service/openrc/openrc.py
@@ -1,24 +1,22 @@
 import logging
 import subprocess
 
-from globals import BOOT_SERVICE_NAME
 from boot_service import BaseBootService
+from globals import BOOT_SERVICE_NAME
 
 
 class Openrc(BaseBootService):
     def _enable(self) -> int:
-        """Enable the service
-
-        Returns:
-            0: the service have been enabled successfully
-            other value: Error with the boot service.
-        """
-        exit_code = subprocess.run(
-            ["rc-update", "add", BOOT_SERVICE_NAME, "default"], capture_output=True
-        ).returncode
-        exit_code += subprocess.run(
-            ["rc-service", BOOT_SERVICE_NAME, "start"], capture_output=True
-        ).returncode
+        exit_code = subprocess.call(
+            ["rc-update", "add", BOOT_SERVICE_NAME, "default"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        exit_code += subprocess.call(
+            ["rc-service", BOOT_SERVICE_NAME, "start"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         if exit_code:
             logging.error("Error with the openrc boot service.")
@@ -26,15 +24,11 @@ class Openrc(BaseBootService):
         return exit_code
 
     def _disable(self) -> int:
-        """Disable the service
-
-        Returns:
-            0: the service have been disabled successfully
-            other value: The boot service does not exists.
-        """
-        exit_code = subprocess.run(
-            ["rc-update", "del", BOOT_SERVICE_NAME, "default"], capture_output=True
-        ).returncode
+        exit_code = subprocess.call(
+            ["rc-update", "del", BOOT_SERVICE_NAME, "default"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         if exit_code:
             logging.error("The openrc boot service does not exists.")
@@ -42,17 +36,13 @@ class Openrc(BaseBootService):
         return exit_code
 
     def status(self) -> int:
-        """Print the service status
-        Returns:
-            0: the service works fine
-            other value: error with the boot service
-        """
         exec = subprocess.run(
-            ["rc-status", "-a"], capture_output=True
+            ["rc-status", "-a"],
+            capture_output=True,
+            text=True,
         )
 
-        output = exec.stdout.decode("utf-8").strip()
-        for line in output.split("\n"):
+        for line in exec.stdout.split("\n"):
             if BOOT_SERVICE_NAME in line:
                 return 0
 

--- a/sources/boot_service/systemd/systemd.py
+++ b/sources/boot_service/systemd/systemd.py
@@ -1,21 +1,17 @@
 import logging
 import subprocess
 
-from globals import BOOT_SERVICE_NAME
 from boot_service import BaseBootService
+from globals import BOOT_SERVICE_NAME
 
 
 class Systemd(BaseBootService):
     def _enable(self) -> int:
-        """Enable the service
-
-        Returns:
-            0: the service have been enabled successfully
-            other value: Error with the boot service.
-        """
-        exit_code = subprocess.run(
-            ["systemctl", "enable", "--now", BOOT_SERVICE_NAME], capture_output=True
-        ).returncode
+        exit_code = subprocess.call(
+            ["systemctl", "enable", "--now", BOOT_SERVICE_NAME],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         if exit_code:
             logging.error("Error with the systemd boot service.")
@@ -23,15 +19,11 @@ class Systemd(BaseBootService):
         return exit_code
 
     def _disable(self) -> int:
-        """Disable the service
-
-        Returns:
-            0: the service have been disabled successfully
-            other value: The boot service does not exists.
-        """
-        exit_code = subprocess.run(
-            ["systemctl", "disable", BOOT_SERVICE_NAME], capture_output=True
-        ).returncode
+        exit_code = subprocess.call(
+            ["systemctl", "disable", BOOT_SERVICE_NAME],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         if exit_code:
             logging.error("The systemd boot service does not exists.")
@@ -39,18 +31,15 @@ class Systemd(BaseBootService):
         return exit_code
 
     def status(self) -> int:
-        """Print the service status
-        Returns:
-            0: the service works fine
-            other value: error with the boot service
-        """
         exec = subprocess.run(
-            ["systemctl", "status", BOOT_SERVICE_NAME], capture_output=True
+            ["systemctl", "status", BOOT_SERVICE_NAME],
+            capture_output=True,
+            text=True,
         )
 
         if exec.returncode == 4:
             logging.error("The systemd boot service does not exists.")
         else:
-            print(exec.stdout.decode("utf-8").strip())
+            print(exec.stdout)
 
         return exec.returncode

--- a/sources/boot_service/systemd/systemd.py
+++ b/sources/boot_service/systemd/systemd.py
@@ -40,6 +40,6 @@ class Systemd(BaseBootService):
         if exec.returncode == 4:
             logging.error("The systemd boot service does not exists.")
         else:
-            print(exec.stdout)
+            print(exec.stdout.strip())
 
         return exec.returncode

--- a/sources/command/boot.py
+++ b/sources/command/boot.py
@@ -1,19 +1,20 @@
-import logging
 from typing import NoReturn
 
-from globals import ExitCode, get_devices, get_boot_service_constructor
+import logging
+
+from globals import ExitCode, get_boot_service_constructor, get_devices
 
 
 def boot(boot_status: str) -> NoReturn:
     """Enable or disable the boot service which
-    activates the ir emitter for all configured device
+    activates the ir emitter for all configured device,
+    and exit.
 
     args:
-        boot_status: "enable" or "disable" or "status"
+        boot_status (str): "enable" or "disable" or "status".
 
     Raises:
-        Exception: boot status arg can only be equal to
-        enable, disable or status
+        Exception (AssertionError): boot_status not in the proposition.
     """
     assert boot_status in ["enable", "disable", "status"]
 

--- a/sources/command/configure.py
+++ b/sources/command/configure.py
@@ -1,28 +1,41 @@
-import logging
 from typing import NoReturn
+
+import logging
 import subprocess
 
-from globals import ExitCode, BIN_DRIVER_GENERATOR_PATH, SAVE_DRIVER_FOLDER_PATH
 from command import boot
+from globals import (BIN_DRIVER_GENERATOR_PATH, SAVE_DRIVER_FOLDER_PATH,
+                     ExitCode)
 
 
 def configure(device: str, emitters: int, neg_answer_limit: int) -> NoReturn:
-    """Find a driver for the infrared camera
+    """Find a driver for the infrared camera and exit.
 
     Args:
-        device: path to the infrared camera
-        emitters: number of emitters on the device
-        neg_answer_limit: after k negative answer the pattern will be skiped. Use 256 for unlimited
+        device str: path to the infrared camera.
+        emitters (int): number of emitters on the device.
+        neg_answer_limit (int): after k negative answer the pattern will be skiped. Use 256 for unlimited.
     """
     logging.info("Ensure to not use the camera during the execution.")
     logging.info("Warning to do not kill the process !")
 
     log_level = int(logging.getLogger().level == logging.DEBUG)
-    exit_code = subprocess.call([BIN_DRIVER_GENERATOR_PATH, device, str(emitters), str(neg_answer_limit), SAVE_DRIVER_FOLDER_PATH, str(log_level)])
+    exit_code = subprocess.call(
+        [
+            BIN_DRIVER_GENERATOR_PATH,
+            device,
+            str(emitters),
+            str(neg_answer_limit),
+            SAVE_DRIVER_FOLDER_PATH,
+            str(log_level),
+        ]
+    )
 
     if exit_code != ExitCode.SUCCESS:
         logging.error("The configuration has failed.")
-        logging.info("Do not hesitate to visit the GitHub ! https://github.com/EmixamPP/linux-enable-ir-emitter/wiki")
+        logging.info(
+            "Do not hesitate to visit the GitHub ! https://github.com/EmixamPP/linux-enable-ir-emitter/wiki"
+        )
     else:
         logging.info("The driver has been successfully generated.")
         boot("enable")

--- a/sources/command/delete.py
+++ b/sources/command/delete.py
@@ -1,23 +1,24 @@
-import os
-import logging
-
 from typing import NoReturn
+
+import logging
+import os
+
 from globals import ExitCode, get_drivers_path
 
 
-def delete(device: str) -> NoReturn:
-    """Remove the driver associated to a device, 
-    without causing error if the driver does not exists
+def delete(device: str | None) -> NoReturn:
+    """Remove the driver associated to a device,
+    without causing error if the driver does not exists,
+    and exit.
 
     Args:
-        device: path to the infrared camera
-                None to execute all driver.
+        device (str | None): path to the infrared camera. None to execute all driver.
     """
     try:
         for driver in get_drivers_path(device):
             os.remove(driver)
     except FileNotFoundError:
-        pass # no driver for this device, but there is no need to send error message
+        pass  # no driver for this device, but there is no need to send error message
 
     logging.info("The drivers have been deleted.")
     exit(ExitCode.SUCCESS)

--- a/sources/command/run.py
+++ b/sources/command/run.py
@@ -1,22 +1,23 @@
-import logging
-import subprocess
 from typing import NoReturn
 
-from globals import ExitCode, BIN_EXECUTE_DRIVER_PATH, get_drivers_path
+import logging
+import subprocess
+
+from globals import BIN_EXECUTE_DRIVER_PATH, ExitCode, get_drivers_path
 
 
-def run(device: str) -> NoReturn:
-    """Apply the driver associated to a device 
+def run(device: str | None) -> NoReturn:
+    """Apply the driver associated to a device and exit.
 
     Args:
-        device: path to the infrared camera
-                None to execute all driver.
+        device (str | None): path to the infrared camera. None to execute all driver.
     """
+
     paths = get_drivers_path(device)
 
     if len(paths) == 0:
         logging.critical("No driver for %s has been configured.", device)
-        exit(ExitCode.FAILURE)            
+        exit(ExitCode.FAILURE)
 
     general_exit_code = ExitCode.SUCCESS
     for driver in paths:

--- a/sources/driver/camera.cpp
+++ b/sources/driver/camera.cpp
@@ -43,8 +43,7 @@ int array_gcd(const uint8_t *arr, uint16_t size)
 int Camera::deviceId(const char *device)
 {
 
-    char *devDevice;
-    devDevice = realpath(device, NULL);
+    char *devDevice = realpath(device, NULL);
     int id;
     if (devDevice == NULL || sscanf(devDevice, "/dev/video%d", &id) != 1)
     {

--- a/sources/globals.py
+++ b/sources/globals.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:

--- a/sources/globals.py
+++ b/sources/globals.py
@@ -93,7 +93,7 @@ def get_index(device: str) -> str:
         "udevadm info -a %s | grep -m 1 -oP 'ATTR{index}==\\K.*'" % (device),
         shell=True,
         text=True,
-    )
+    ).strip()
 
 
 def get_kernels(device: str) -> str:
@@ -109,4 +109,4 @@ def get_kernels(device: str) -> str:
         "udevadm info -a %s | grep -m 1 -oP 'KERNELS==\\K.*'" % (device),
         shell=True,
         text=True,
-    )
+    ).strip()

--- a/sources/globals.py
+++ b/sources/globals.py
@@ -1,12 +1,17 @@
-import os
+from typing import TYPE_CHECKING, Type
+
+if TYPE_CHECKING:
+    from boot_service.systemd import Systemd
+    from boot_service.openrc import Openrc
+
 import enum
-import logging
-import sys
-import subprocess
 import glob
-import re
 import importlib
-from typing import List, Any
+import logging
+import os
+import re
+import subprocess
+import sys
 
 SAVE_DRIVER_FOLDER_PATH = "@SAVE_DRIVER_FOLDER_PATH@"
 
@@ -26,75 +31,81 @@ class ExitCode(enum.IntEnum):
 
 
 def check_root() -> None:
-    """Exit if the script isn't run as root"""
+    """Exit if the script isn't run as root."""
     if os.getuid():
         logging.critical("Please run as root.")
         sys.exit(ExitCode.ROOT_REQUIRED)
 
 
-def get_boot_service_constructor() -> Any:
-    """Get the installed boot service constructor
+def get_boot_service_constructor() -> Type[Systemd] | Type[Openrc] | None:
+    """Get the installed boot service constructor.
 
     Returns:
-        Any: Systemd or Openrc
-        None: no boot service installed
+        Systemd | Openrc | None: Systemd or Openrc class constructor.
+        None if no boot service is installed.
     """
     try:
-        module = importlib.import_module(
-            f"boot_service.{BOOT_SERVICE_MANAGER}")
+        module = importlib.import_module(f"boot_service.{BOOT_SERVICE_MANAGER}")
         return getattr(module, BOOT_SERVICE_MANAGER)
-    except Exception as e:
-        print(e)
+    except:
         return None
 
 
-def get_drivers_path(device: str = None) -> str:
+def get_drivers_path(device: str | None) -> list[str]:
     """Get the drivers path corresponding to all configured device
-    or just to one specific
+    or just to one specific.
 
     Args:
-        device: path to the a specific infrared camera
-                None to get all drivers path.
+        device (str | None): path to the a specific infrared camera.
+        None to get all drivers path.
 
     Returns:
-        str: path to the driver(s)
+        list[str]: path(s) to the driver(s).
     """
     driverName = "*"
     if device is not None:
-        driverName = device[device.rfind("/") + 1:] + driverName
+        driverName = device[device.rfind("/") + 1 :] + driverName
     path = os.path.join(SAVE_DRIVER_FOLDER_PATH, driverName + ".driver")
     return glob.glob(path)
 
 
-def get_devices() -> List[str]:
-    """Return all configured devices"""
+def get_devices() -> list[str]:
+    """Return all configured devices."""
     devices_path = []
     for driver in os.listdir(SAVE_DRIVER_FOLDER_PATH):
         if re.match(r".*_emitter[0-9]+.driver", driver):
-            path = "/dev/v4l/by-path/" + driver[:driver.rfind("_emitter")]
+            path = "/dev/v4l/by-path/" + driver[: driver.rfind("_emitter")]
             devices_path.append(path)
     return devices_path
 
 
 def get_index(device: str) -> str:
-    """Get the index of the camera device
+    """Get the index of the camera device.
 
     Args:
-        device: the infrared camera '/dev/videoX'
+        device (str): the infrared camera '/dev/videoX'.
 
     Returns:
-        device index (double quoted)
+        str: device index (double quoted).
     """
-    return subprocess.check_output("udevadm info -a %s | grep -m 1 -oP 'ATTR{index}==\\K.*'" % (device), shell=True).decode("utf-8").strip()
+    return subprocess.check_output(
+        "udevadm info -a %s | grep -m 1 -oP 'ATTR{index}==\\K.*'" % (device),
+        shell=True,
+        text=True,
+    )
 
 
 def get_kernels(device: str) -> str:
-    """Get the parent kernels of the camera device
+    """Get the parent kernels of the camera device.
 
     Args:
-        device: the infrared camera '/dev/videoX'
+        device (str): the infrared camera '/dev/videoX'.
 
     Returns:
-        device parent kernels (double quoted)
+        str: device parent kernels (double quoted).
     """
-    return subprocess.check_output("udevadm info -a %s | grep -m 1 -oP 'KERNELS==\\K.*'" % (device), shell=True).decode("utf-8").strip()
+    return subprocess.check_output(
+        "udevadm info -a %s | grep -m 1 -oP 'KERNELS==\\K.*'" % (device),
+        shell=True,
+        text=True,
+    )

--- a/sources/linux-enable-ir-emitter.py
+++ b/sources/linux-enable-ir-emitter.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
             shell=True,
             capture_output=True,
             text=True,
-        ).stdout
+        ).stdout.strip()
         if len(v4l_device) == 0:
             logging.critical(
                 f"The device {device} does not exists or is not a supported v4l camera."

--- a/sources/linux-enable-ir-emitter.py
+++ b/sources/linux-enable-ir-emitter.py
@@ -4,61 +4,78 @@ import argparse
 import logging
 import subprocess
 
-from command import boot, run, configure, delete
+from command import boot, configure, delete, run
 from globals import ExitCode, check_root
 
 if __name__ == "__main__":
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
     parser = argparse.ArgumentParser(
         description="Provides support for infrared cameras.",
         prog="linux-enable-ir-emitter",
         epilog="For support visit https://github.com/EmixamPP/linux-enable-ir-emitter/wiki",
-        formatter_class=argparse.RawTextHelpFormatter
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
-        "-v", "--verbose", 
+        "-v",
+        "--verbose",
         help="print verbose information",
-        action='store_true', 
-        default=False
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
-        "-V", "--version",
+        "-V",
+        "--version",
         action="version",
         version="%(prog)s @version@\nDevelopped by Maxime Dirksen - EmixamPP\nMIT License",
-        help="show version information and exit"
+        help="show version information and exit",
     )
     parser.add_argument(
-        "-d", "--device",
+        "-d",
+        "--device",
         metavar="device",
         help="specify the infrared camera, by default is '/dev/video2'",
-        nargs=1
+        nargs=1,
     )
-    command_subparser = parser.add_subparsers(dest='command')
-    command_run = command_subparser.add_parser("run", help="apply drivers")
-    command_configure = command_subparser.add_parser("configure", help="generate ir emitter driver")
+    command_subparser = parser.add_subparsers(dest="command")
+    command_run = command_subparser.add_parser(
+        "run",
+        help="apply drivers",
+    )
+    command_configure = command_subparser.add_parser(
+        "configure",
+        help="generate ir emitter driver",
+    )
     command_configure.add_argument(
-        "-e", "--emitters",
+        "-e",
+        "--emitters",
         metavar="<count>",
         help="the number of emitters on the device, by default is 1",
         default=[1],
         type=int,
-        nargs=1
+        nargs=1,
     )
     command_configure.add_argument(
-        "-l", "--limit",
+        "-l",
+        "--limit",
         metavar="<count>",
         help="the number of negative answer before the pattern is skiped, by default is 5. Use 256 for unlimited",
         default=[5],
         type=int,
-        nargs=1
+        nargs=1,
     )
-    command_delete = command_subparser.add_parser("delete", help="delete drivers")
-    command_boot = command_subparser.add_parser("boot", help="enable ir at boot")
+    command_delete = command_subparser.add_parser(
+        "delete",
+        help="delete drivers",
+    )
+    command_boot = command_subparser.add_parser(
+        "boot",
+        help="enable ir at boot",
+    )
     command_boot.add_argument(
-        "boot_status", 
-        choices=["enable", "disable", "status"], 
-        help="specify the boot action to perform"
+        "boot_status",
+        choices=["enable", "disable", "status"],
+        help="specify the boot action to perform",
     )
 
     args = parser.parse_args()
@@ -66,32 +83,41 @@ if __name__ == "__main__":
     if args.verbose:  # enable verbosity
         logging.getLogger().setLevel(logging.DEBUG)
 
-    device = None
+    device: str | None = None
     # Determine the device if needed
     # In case of configuration: use the specified device otherwise the default one (i.e. /dev/video2)
     # In case of run or delete: use the specified device
-    if args.command == "configure" or (args.device and args.command in ("run", "delete")):
+    if args.command == "configure" or (
+        args.device and args.command in ("run", "delete")
+    ):
         device = args.device[0] if args.device else "/dev/video2"
         # Find the v4l path
-        v4l_device = subprocess.run(f"find -L /dev/v4l/by-path -samefile {device}", shell=True, capture_output=True)
-        v4l_device = v4l_device.stdout.decode('utf-8').strip()
-        if (len(v4l_device) == 0):
-            logging.critical(f"The device {device} does not exists or is not a supported v4l camera.")
+        v4l_device = subprocess.run(
+            f"find -L /dev/v4l/by-path -samefile {device}",
+            shell=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        if len(v4l_device) == 0:
+            logging.critical(
+                f"The device {device} does not exists or is not a supported v4l camera."
+            )
             exit(ExitCode.FAILURE)
         device = v4l_device
-        
+
     # Execute the desired command
     if args.command == "run":
         run(device)
 
     elif args.command == "configure":
         check_root()
+        assert(device is not None)
         configure(device, args.emitters[0], args.limit[0])
 
     elif args.command == "boot":
         check_root()
         boot(args.boot_status)
-    
+
     elif args.command == "delete":
         check_root()
         delete(device)


### PR DESCRIPTION
linux-enable-ir-emitter requires now `python >= 3.10`, because of syntax used for stricter type checking. 
