### PR TITLE
Generate shared library instead of static

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
     version: '5.2.0', 
     license: 'MIT',
     default_options: [
-        'default_library=static',
+        'default_library=shared',
         'prefix=/usr',
         'cpp_std=c++17',
         'optimization=3',


### PR DESCRIPTION
Latest version fails any command with the following error:

```
Traceback (most recent call last):
  File "/usr/bin/linux-enable-ir-emitter", line 11, in <module>
    from command import boot, cpp_commands
  File "/usr/lib/linux-enable-ir-emitter/command/__init__.py", line 2, in <module>
    from command.load_cpp_commands import *
  File "/usr/lib/linux-enable-ir-emitter/command/load_cpp_commands.py", line 5, in <module>
    cpp_commands = ctypes.CDLL(CPP_COMMANDS_LIB_PATH)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: /usr/lib/linux-enable-ir-emitter/libcommands.so: cannot open shared object file: No such file or directory
```

The reason is that, by default a static library is generated, but you try to load `libcommands.so` instead of `libcommands.a`

This fixes latest version by generating a shared library instead.