### PR TITLE
Fix: Driver configured but not found & OpenCV exception on video feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Wed Nov 1 2023 - 5.2.4
+- Fix driver generated but not found
+- Fix for OpenCV exception thrown
+- Reduction in installation size
 # Fri Oct 20 2023 - 5.2.1
 - Fix unable to execute commands
 # Thu Oct 19 2023 - 5.2.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ We also support OpenRC, just download the `.openrc` variant.
 It can be uninstalled by executing (remove the last line to keep the emitter configuration):
 ```
 sudo rm -rf /usr/lib64/linux-enable-ir-emitter \
-/usr/libexec/linux-enable-ir-emitter \
 /usr/bin/linux-enable-ir-emitter \
 /usr/lib/systemd/system/linux-enable-ir-emitter.service \
 /etc/udev/rules.d/99-linux-enable-ir-emitter.rules \

--- a/camera/camera.hpp
+++ b/camera/camera.hpp
@@ -18,6 +18,7 @@ private:
     int id;
     int fd = -1;
     const shared_ptr<cv::VideoCapture> cap = make_shared<cv::VideoCapture>();
+    bool noGui = false;
 
 protected:
     int getFd() const noexcept;
@@ -35,6 +36,10 @@ protected:
     static int deviceId(const string &device);
 
     int executeUvcQuery(const uvc_xu_control_query &query);
+
+    bool isEmitterWorkingAsk();
+
+    bool isEmitterWorkingAskNoGui();
 
 public:
     const string device;
@@ -59,7 +64,7 @@ public:
 
     virtual bool isEmitterWorking();
 
-    unique_ptr<cv::Mat> read1();
+    shared_ptr<cv::Mat> read1();
 
     int setUvcQuery(uint8_t unit, uint8_t selector, vector<uint8_t> &control);
 
@@ -70,6 +75,8 @@ public:
     bool isGrayscale();
 
     static shared_ptr<Camera> findGrayscaleCamera();
+
+    void disableGui();
 };
 
 class CameraException : public exception

--- a/command/commands.hpp
+++ b/command/commands.hpp
@@ -8,7 +8,7 @@ using namespace std;
 
 extern "C"
 {
-    ExitCode configure(const char* device, bool manual, unsigned emitters, unsigned negAnswerLimit);
+    ExitCode configure(const char* device, bool manual, unsigned emitters, unsigned negAnswerLimit, bool noGui);
     ExitCode delete_driver(const char* device);
     ExitCode run(const char* device);
     ExitCode test(const char* device);

--- a/command/configure.cpp
+++ b/command/configure.cpp
@@ -22,10 +22,11 @@ void enableDebug()
  * @param manual true for enabling the manual configuration
  * @param emitters number of emitters on the device
  * @param negAnswerLimit number of negative answer before the pattern is skiped. Use -1 for unlimited
+ * @param noGui no gui video feedback
  *
  * @return exit code
  */
-ExitCode configure(const char *device_char_p, bool manual, unsigned emitters, unsigned negAnswerLimit)
+ExitCode configure(const char *device_char_p, bool manual, unsigned emitters, unsigned negAnswerLimit, bool noGui)
 {
     const string device = string(device_char_p);
 
@@ -48,6 +49,9 @@ ExitCode configure(const char *device_char_p, bool manual, unsigned emitters, un
         else
             camera = make_shared<AutoCamera>(device);
     }
+
+    if (noGui) 
+        camera->disableGui();
 
     if (camera == nullptr)
         Logger::critical(ExitCode::FAILURE, "Impossible to find an infrared camera.");

--- a/command/configure.cpp
+++ b/command/configure.cpp
@@ -58,7 +58,7 @@ ExitCode configure(const char *device_char_p, bool manual, unsigned emitters, un
 
     Logger::info("Configuring the camera:", camera->device, ".");
 
-    const string deviceName = device.substr(device.find_last_of("/") + 1);
+    const string deviceName = camera->device.substr(camera->device.find_last_of("/") + 1);
     const string excludedPath = SAVE_DRIVER_FOLDER_PATH + deviceName + ".excluded";
     Finder finder(*camera, emitters, negAnswerLimit, excludedPath);
 

--- a/command/load_cpp_commands.py
+++ b/command/load_cpp_commands.py
@@ -9,6 +9,7 @@ cpp_commands.configure.argtypes = [
     ctypes.c_bool,
     ctypes.c_uint32,
     ctypes.c_uint32,
+    ctypes.c_bool,
 ]
 cpp_commands.configure.restype = ctypes.c_int
 

--- a/linux-enable-ir-emitter.py
+++ b/linux-enable-ir-emitter.py
@@ -71,6 +71,13 @@ if __name__ == "__main__":
         default=40,
         type=int,
     )
+    command_configure.add_argument(
+        "-g",
+        "--no-gui",
+        help="no gui video feedback",
+        action="store_true",
+        default=False,
+    )
     command_test = command_subparser.add_parser(
         "test",
         help="test a camera",
@@ -119,7 +126,13 @@ if __name__ == "__main__":
 
     elif args.command == "configure":
         check_root()
-        res = cpp_commands.configure(device.encode(), args.manual, args.emitters, args.limit)
+        res = cpp_commands.configure(
+            device.encode(),
+            args.manual,
+            args.emitters,
+            args.limit,
+            args.no_gui
+        )
         if res == ExitCode.SUCCESS:
             boot("enable")
 

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project(
     'linux-enable-ir-emitter', 
     'cpp',
-    version: '5.2.1', 
+    version: '5.2.3', 
     license: 'MIT',
     default_options: [
         'prefix=/usr',
         'cpp_std=c++17',
-        'optimization=3',
+        'buildtype=release',
         'warning_level=everything',
         'werror=true',
     ],

--- a/utils/globals.hpp.in
+++ b/utils/globals.hpp.in
@@ -6,7 +6,7 @@
 #include <vector>
 using namespace std;
 
-const string SAVE_DRIVER_FOLDER_PATH = "@SAVE_DRIVER_FOLDER_PATH@";
+const string SAVE_DRIVER_FOLDER_PATH = "@SAVE_DRIVER_FOLDER_PATH@/";
 
 enum ExitCode
 {


### PR DESCRIPTION
* Provides a `--no-gui` option in order to avoid OpenCV exception on video feedback.
* Fix the error `CRITICAL: No driver have been configured.` after `INFO: The driver has been successfully generated.`
