### PR TITLE
Improved ctrl-c handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Save of all the camera instructions
 - Tweak manually any instructions of a camera
 - Specify camera resolution
-- Catch ctrl-c (one time) to avoid breaking camera
+- Catch ctrl-c to avoid breaking camera
 - Zsh completion
 - Fix video feedback freeze
 - Better logging
@@ -13,6 +13,7 @@
 - Remove boot command
 - Migrate all Python code to C++
 - Reduction in installation size
+- Fix size assertion exception
 # Wed Nov 1 2023 - 5.2.4
 - Fix config generated but not found
 - Fix for OpenCV exception thrown

--- a/command/commands.hpp
+++ b/command/commands.hpp
@@ -5,11 +5,11 @@
 #include "configuration.hpp"
 
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <regex>
 #include <string>
-#include <signal.h>
 using namespace std;
 
 enum ExitCode
@@ -19,26 +19,6 @@ enum ExitCode
     ROOT_REQUIRED = 2,
     FILE_DESCRIPTOR_ERROR = 126,
 };
-
-/**
- * @brief Catch ctrl-c signal one time.
- */
-inline void CatchCtrlC()
-{
-    auto handler = [](int signal)
-    {
-        if (signal == SIGINT)
-        {
-            static int ctrlc_counter = 0;
-            ++ctrlc_counter;
-            if (ctrlc_counter == 2)
-                exit(ExitCode::FAILURE);
-            cout << " Ctrl-c again if you really want to, be careful this could break the camera." << endl;
-        }
-    };
-
-    signal(SIGINT, std::move(handler));
-}
 
 /**
  * @brief Creates a Camera or AutoCamera object.

--- a/command/configure.cpp
+++ b/command/configure.cpp
@@ -30,10 +30,9 @@ ExitCode configure(const optional<string> &device, int width, int height,
 {
     Logger::debug("Executing configure command.");
 
-    CatchCtrlC();
-
     Logger::info("Stand in front of and close to the camera and make sure the room is well lit.");
     Logger::info("Ensure to not use the camera during the execution.");
+    Logger::info("Do not kill the process, unless you really need to, and only use ctrl-c.");
 
     bool success = false;
     try

--- a/command/configure.cpp
+++ b/command/configure.cpp
@@ -46,13 +46,13 @@ ExitCode configure(const optional<string> &device, int width, int height,
 
         Logger::info("Configuring the camera", camera->device());
 
-        auto instructions = Configuration::Load(camera->device());
+        auto instructions = Configuration::LoadInit(camera->device());
         if (!instructions)
         {
             Logger::debug("No previous configuration found.");
             Scanner scanner(camera);
             instructions = scanner.scan();
-            Configuration::Save(camera->device(), instructions.value());
+            Configuration::SaveInit(camera->device(), instructions.value());
         }
         else
             Logger::debug("Previous configuration found.");

--- a/command/run.cpp
+++ b/command/run.cpp
@@ -51,7 +51,7 @@ ExitCode run(const optional<string> &device, int width, int height)
         {
             for (const auto &instruction : instructions.value())
             {
-                Logger::debug("Applying instruction", to_string(instruction), "on", device);
+                Logger::info("Applying instruction", to_string(instruction), "on", device);
                 if (!camera.apply(instruction))
                 {
                     Logger::error("Failed to apply the instruction", to_string(instruction));

--- a/command/tweak.cpp
+++ b/command/tweak.cpp
@@ -19,8 +19,6 @@ ExitCode tweak(const optional<string> &device, int width, int height)
 {
     Logger::debug("Executing tweak command.");
 
-    CatchCtrlC();
-
     bool saved = false;
     try
     {

--- a/configuration/finder.cpp
+++ b/configuration/finder.cpp
@@ -36,7 +36,7 @@ bool Finder::find(CameraInstructions &intructions)
     {
         if (instruction.is_corrupted())
         {
-            Logger::debug("Corrupted instruction skipped:", to_string(instruction));
+            Logger::info("Corrupted instruction skipped:", to_string(instruction));
             continue;
         }
 
@@ -50,7 +50,7 @@ bool Finder::find(CameraInstructions &intructions)
                 if (neg_answer_counter == neg_answer_limit_ - 1)
                     instruction.set_max_cur();
 
-                Logger::debug("Instruction applied:", to_string(instruction));
+                Logger::info("Instruction applied:", to_string(instruction));
 
                 if (camera_->apply(instruction))
                 {
@@ -65,13 +65,13 @@ bool Finder::find(CameraInstructions &intructions)
                     }
                 }
                 else
-                    Logger::debug("The instruction is not valid.");
+                    Logger::info("The instruction is not valid.");
 
                 ++neg_answer_counter;
             }
 
             instruction.reset();
-            Logger::debug("Reseting to the instruction:", to_string(instruction));
+            Logger::info("Reseting to the instruction:", to_string(instruction));
             camera_->apply(instruction);
         }
         catch (const CameraInstructionException &e)

--- a/configuration/finder.cpp
+++ b/configuration/finder.cpp
@@ -1,6 +1,7 @@
 #include "finder.hpp"
 
 #include <fstream>
+#include <signal.h>
 #include <string>
 #include <thread>
 using namespace std;
@@ -18,6 +19,7 @@ using namespace std;
 Finder::Finder(shared_ptr<Camera> camera, unsigned emitters, unsigned neg_answer_limit)
     : camera_(camera), emitters_(emitters), neg_answer_limit_(neg_answer_limit) {}
 
+bool force_exit = false;
 /**
  * @brief Find an instruction which enable the ir emitter(s)
  * by changing its value.
@@ -30,6 +32,11 @@ Finder::Finder(shared_ptr<Camera> camera, unsigned emitters, unsigned neg_answer
  */
 bool Finder::find(CameraInstructions &intructions)
 {
+    signal(SIGINT, [](int signal)
+           { if (signal == SIGINT) { 
+            Logger::info("The process will exit as soon as possible.");
+            force_exit = true;} });
+
     unsigned configured = 0;
 
     for (auto &instruction : intructions)
@@ -47,6 +54,9 @@ bool Finder::find(CameraInstructions &intructions)
             unsigned neg_answer_counter = 0;
             while (neg_answer_counter < neg_answer_limit_ && instruction.next())
             {
+                if (force_exit)
+                    break;
+
                 if (neg_answer_counter == neg_answer_limit_ - 1)
                     instruction.set_max_cur();
 
@@ -73,6 +83,9 @@ bool Finder::find(CameraInstructions &intructions)
             instruction.reset();
             Logger::info("Reseting to the instruction:", to_string(instruction));
             camera_->apply(instruction);
+
+            if (force_exit)
+                return false;
         }
         catch (const CameraInstructionException &e)
         {

--- a/utils/configuration.hpp.in
+++ b/utils/configuration.hpp.in
@@ -11,9 +11,13 @@ namespace Configuration
 {
     const string SAVE_FOLDER_CONFIG_PATH_ = "@configdir@/";
 
-    bool Save(const string &device, const CameraInstructions &instructions);
+    bool Save(const string &device, const CameraInstructions &instructions, optional<string> path = {});
 
-    optional<CameraInstructions> Load(const string &device) noexcept;
+    bool SaveInit(const string &device, const CameraInstructions &instructions);
+
+    optional<CameraInstructions> Load(const string &device, optional<string> path = {}) noexcept;
+
+    optional<CameraInstructions> LoadInit(const string &device) noexcept;
 
     vector<string> ConfiguredDevices() noexcept;
 }


### PR DESCRIPTION
When the user ctrl-c, the process will exit gracefully, avoiding breaking the camera. In addition, debug log have been promoted to info in order to let know if the process is stuck or not (very unlikely). Finally, a separate (in addition to the current initial value store in the main configuration) backup of the initial configuration is saved for better resetting of the camera.