### PR TITLE
meson: don't prepend /

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup build
         run: |
-          meson setup build --libdir=lib --prefer-static --pkg-config-path=$(find .github -name "pkgconfig")
+          meson setup build --sysconfdir /etc --prefer-static --pkg-config-path $(find .github -name "pkgconfig")
           case "${{ inputs.buildtype }}" in
             "release")
               meson configure build --optimization=s --strip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: thollander/actions-comment-pull-request@v2
+      - uses: thollander/actions-comment-pull-request@v3
         with:
           comment_tag: bot_comment
           mode: recreate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Fri Oct 11 2024 - 6.0.6
+- Better building system compatibility
 # Wed Oct 2 2024 - 6.0.5
 - Fix fmt lib compatibility
 # Fri Sept 30 2024 - 6.0.4

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ spdlog_dep = dependency('spdlog', include_type: 'system')
 ############
 # Variable #
 ############
-sysconf_dir = '/' / get_option('sysconfdir') / meson.project_name()
+sysconf_dir = get_option('sysconfdir') / meson.project_name()
 log_dir = get_option('localstatedir') / 'log' / meson.project_name()
 cfg_data = configuration_data(
     {
@@ -80,12 +80,12 @@ install_data(
 if get_option('boot_service') == 'systemd'
     install_data(
         'boot_service/systemd/linux-enable-ir-emitter.service',
-        install_dir: '/' / get_option('sysconfdir') / 'systemd/system',
+        install_dir: get_option('sysconfdir') / 'systemd/system',
     )
 elif get_option('boot_service') == 'openrc'
     install_data(
         'boot_service/openrc/linux-enable-ir-emitter',
-        install_dir: '/' / get_option('sysconfdir') / 'init.d',
+        install_dir: get_option('sysconfdir') / 'init.d',
     )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'linux-enable-ir-emitter',
     'cpp',
-    version: '6.0.5',
+    version: '6.0.6',
     license: 'MIT',
     default_options: [
         'cpp_std=c++20',

--- a/meson.build
+++ b/meson.build
@@ -39,25 +39,20 @@ spdlog_dep = dependency('spdlog', include_type: 'system')
 ############
 # Variable #
 ############
-sysconf_dir = get_option('sysconfdir') / meson.project_name()
+config_dir = get_option('sysconfdir') / meson.project_name()
 log_dir = get_option('localstatedir') / 'log' / meson.project_name()
-cfg_data = configuration_data(
-    {
-        'version': meson.project_version(),
-        'configdir': sysconf_dir,
-        'log_file': log_dir / meson.project_name() + '.log',
-    },
-)
 
 ##############
 # Executable #
 ##############
 subdir('src')
 
-#################
-# Configuration #
-#################
-install_emptydir(sysconf_dir)
+################
+# Config + Log #
+################
+install_emptydir(config_dir)
+
+install_emptydir(log_dir)
 
 ####################
 # Shell completion #
@@ -92,8 +87,6 @@ endif
 ##########
 # Others #
 ##########
-install_emptydir(log_dir)
-
 install_data(
     'README.md',
     install_dir: get_option('datadir') / 'doc' / meson.project_name(),

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,11 @@
+cfg_data = configuration_data(
+    {
+        'version': meson.project_version(),
+        'configdir': config_dir,
+        'log_file': log_dir / meson.project_name() + '.log',
+    },
+)
+
 configure_file(
     input: 'linux-enable-ir-emitter.cpp.in',
     output: 'linux-enable-ir-emitter.cpp',


### PR DESCRIPTION
Prepending `/` renders `prefix` useless, so users cannot customize the install location.

This is especially a problem with build systems that use per-package prefixes, such as Guix or Nix.
